### PR TITLE
Add a new option to override the nameserver of the cloudflared tunnel

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -25,7 +25,7 @@ config:
       type: string
       description: >-
         The nameserver used by the cloudflared tunnel.
-        Cloudflared will use system's default resolver if this option is not set.
+        Cloudflared will use kube DNS if this option is not set.
     tunnel-token:
       description: >-
         A juju secret ID, points to a juju secret containing the cloudflared tunnel-token.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,11 @@ config:
     domain:
       description: The hostname the app is exposed on cloudflare.
       type: string
+    nameserver:
+      type: string
+      description: >-
+        The nameserver used by the cloudflared tunnel.
+        Cloudflared will use system's default resolver if this option is not set.
     tunnel-token:
       description: >-
         A juju secret ID, points to a juju secret containing the cloudflared tunnel-token.

--- a/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
+++ b/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 _TUNNEL_TOKEN_SECRET_ID_FIELD = "tunnel_token_secret_id"
 _TUNNEL_TOKEN_SECRET_VALUE_FIELD = "tunnel-token"
@@ -150,7 +150,7 @@ class CloudflaredRouteRequirer:
             ) from exc
 
     def get_nameserver(self, relation: ops.Relation) -> str | None:
-        """the nameserver used by the Cloudflared tunnel.
+        """Get the nameserver used by the Cloudflared tunnel.
 
         Args:
             relation: relation to receive the tunnel-token from.

--- a/src/charm.py
+++ b/src/charm.py
@@ -66,6 +66,7 @@ class CloudflareConfiguratorCharm(ops.CharmBase):
             return
         if relation := self.model.get_relation("cloudflared-route"):
             self._cloudflare_route.set_tunnel_token(tunnel_token, relation=relation)
+            self._cloudflare_route.set_nameserver(self.config.get("nameserver"), relation=relation)
             if self._ingress.relations:
                 self._ingress.publish_url(self._ingress.relations[0], f"https://{domain}")
         else:

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@
 
 import json
 import logging
+import socket
 import typing
 
 import ops
@@ -66,11 +67,24 @@ class CloudflareConfiguratorCharm(ops.CharmBase):
             return
         if relation := self.model.get_relation("cloudflared-route"):
             self._cloudflare_route.set_tunnel_token(tunnel_token, relation=relation)
-            self._cloudflare_route.set_nameserver(self.config.get("nameserver"), relation=relation)
+            self._cloudflare_route.set_nameserver(
+                self.config.get("nameserver") or self._get_k8s_dns(), relation=relation
+            )
             if self._ingress.relations:
                 self._ingress.publish_url(self._ingress.relations[0], f"https://{domain}")
         else:
             self._unpublish_ingress_url()
+
+    def _get_k8s_dns(self) -> str | None:
+        """Retrieve the current k8s dns address being used.
+
+        Returns:
+            The address of the k8s dns.
+        """
+        try:
+            return socket.gethostbyname("kube-dns.kube-system.svc")
+        except socket.error:
+            return None
 
     def _unpublish_ingress_url(self) -> None:
         """Unpublish ingress url."""


### PR DESCRIPTION
### Overview

Add a new option to override the nameserver used by the cloudflared tunnel

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
