### PR TITLE
Refactor the `cloudflared_route` charm library

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -42,7 +42,7 @@ provides:
     interface: ingress
     limit: 1
   cloudflared-route:
-    interface: cloudflared-route
+    interface: cloudflared_route
     limit: 1
 
 base: ubuntu@24.04

--- a/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
+++ b/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
@@ -109,15 +109,28 @@ class CloudflaredRouteRequirer(ops.Object):
     """cloudflared-route requirer."""
 
     @classmethod
-    def list(
+    def get_all(
         cls,
         charm: ops.CharmBase,
         relation_name: str = DEFAULT_CLOUDFLARED_ROUTE_RELATION,
     ) -> list[typing.Self]:
+        """Retrieve all CloudflaredRouteRequirer objects for the cloudflared-route integration.
+
+        This method generates a list of CloudflaredRouteRequirer instances,
+        each corresponding to a cloudflared-route integration available.
+
+        Args:
+            charm: The charm instance.
+            relation_name: The name of the relation.
+
+        Returns:
+            A list of CloudflaredRouteRequirer objects for each integration.
+        """
         relations = charm.model.relations[relation_name]
         return [cls(charm=charm, relation=relation) for relation in relations]
 
     def __init__(self, charm: ops.CharmBase, relation: ops.Relation):
+        """Instantiate the cloudflared-route requirer."""
         super().__init__(charm, f"{relation.name}-{relation.id}")
         self._charm = charm
         self.relation = relation

--- a/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
+++ b/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
@@ -62,7 +62,7 @@ class CloudflaredRouteProvider(ops.Object):
             self._charm.on[relation_name].relation_broken, self._on_relation_broken
         )
 
-    def set_tunnel_token(self, tunnel_token: str | None) -> None:
+    def set_tunnel_token(self, tunnel_token: typing.Optional[str]) -> None:
         """Update the cloudflared tunnel token in the integration data,
             no-op if there's no integration.
 
@@ -87,7 +87,7 @@ class CloudflaredRouteProvider(ops.Object):
             if secret.get_content(refresh=True) != content:
                 secret.set_content(content)
 
-    def set_nameserver(self, nameserver: str | None) -> None:
+    def set_nameserver(self, nameserver: typing.Optional[str]) -> None:
         """Update the nameserver setting in the integration data.
 
         Args:
@@ -113,7 +113,7 @@ class CloudflaredRouteRequirer(ops.Object):
         cls,
         charm: ops.CharmBase,
         relation_name: str = DEFAULT_CLOUDFLARED_ROUTE_RELATION,
-    ) -> list[typing.Self]:
+    ) -> list["CloudflaredRouteRequirer"]:
         """Retrieve all CloudflaredRouteRequirer objects for the cloudflared-route integration.
 
         This method generates a list of CloudflaredRouteRequirer instances,
@@ -135,7 +135,7 @@ class CloudflaredRouteRequirer(ops.Object):
         self._charm = charm
         self.relation = relation
 
-    def get_tunnel_token(self) -> str | None:
+    def get_tunnel_token(self) -> typing.Optional[str]:
         """Get cloudflared tunnel-token from the integration data.
 
         Returns:
@@ -156,7 +156,7 @@ class CloudflaredRouteRequirer(ops.Object):
                 f"secret doesn't have '{_TUNNEL_TOKEN_SECRET_VALUE_FIELD}' field"
             ) from exc
 
-    def get_nameserver(self) -> str | None:
+    def get_nameserver(self) -> typing.Optional[str]:
         """Get the nameserver setting from the integration data.
 
         Returns:

--- a/src/charm.py
+++ b/src/charm.py
@@ -70,9 +70,7 @@ class CloudflareConfiguratorCharm(ops.CharmBase):
             self._cleanup()
             return
         self._cloudflare_route.set_tunnel_token(tunnel_token)
-        self._cloudflare_route.set_nameserver(
-            self.config.get("nameserver") or self._get_k8s_dns()
-        )
+        self._cloudflare_route.set_nameserver(self.config.get("nameserver") or self._get_k8s_dns())
         if self._ingress.relations:
             self._ingress.publish_url(self._ingress.relations[0], f"https://{domain}")
         self.unit.status = ops.ActiveStatus()

--- a/src/charm.py
+++ b/src/charm.py
@@ -75,7 +75,8 @@ class CloudflareConfiguratorCharm(ops.CharmBase):
             self._ingress.publish_url(self._ingress.relations[0], f"https://{domain}")
         self.unit.status = ops.ActiveStatus()
 
-    def _cleanup(self):
+    def _cleanup(self) -> None:
+        """Teardown charm integrations."""
         if self._cloudflare_route.relation:
             self._cloudflare_route.set_nameserver(nameserver=None)
             self._cloudflare_route.set_tunnel_token(tunnel_token=None)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -158,7 +158,8 @@ def test_no_domain_config():
         ),
     )
 
-    assert out.unit_status == ops.testing.BlockedStatus("waiting for domain configuration")
+    assert out.unit_status.name == "waiting"
+    assert out.unit_status.message == "waiting for domain configuration"
 
 
 def test_no_tunnel_token_config():
@@ -180,7 +181,8 @@ def test_no_tunnel_token_config():
         ),
     )
 
-    assert out.unit_status == ops.testing.BlockedStatus("waiting for tunnel-token configuration")
+    assert out.unit_status.name == "waiting"
+    assert out.unit_status.message == "waiting for tunnel-token configuration"
 
 
 def test_unpublish_ingress_url():

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.5.2.0
+    juju==3.5.2.1
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Refactor and resolve a bug in the `cloudflared_route` charm library.

Fixes:
  - The `set_tunnel_token` function is now idempotent without bumping the secret revision.

Refactoring:
  - `CloudflaredRouteProvider` now assumes a maximum of one integration exists, with an updated interface to reflect this.
  - `CloudflaredRouteRequirer` is now instantiated for each `cloudflared-route` integration, and its interface has been updated accordingly.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
