### PR TITLE
Only update secret content when necessary

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -12,4 +12,4 @@ jobs:
       self-hosted-runner-label: "edge"
       charmcraft-channel: latest/edge
       provider: lxd
-      juju-channel: 3.4/stable
+      juju-channel: 3.6/stable

--- a/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
+++ b/lib/charms/cloudflare_configurator/v0/cloudflared_route.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 _TUNNEL_TOKEN_SECRET_ID_FIELD = "tunnel_token_secret_id"
 _TUNNEL_TOKEN_SECRET_VALUE_FIELD = "tunnel-token"
@@ -79,7 +79,9 @@ class CloudflaredRouteProvider(ops.Object):
             relation_data[_TUNNEL_TOKEN_SECRET_ID_FIELD] = secret.id
         else:
             secret = self._charm.model.get_secret(id=secret_id)
-            secret.set_content({_TUNNEL_TOKEN_SECRET_VALUE_FIELD: tunnel_token})
+            content = secret.get_content(refresh=True)
+            if content[_TUNNEL_TOKEN_SECRET_VALUE_FIELD] != tunnel_token:
+                secret.set_content({_TUNNEL_TOKEN_SECRET_VALUE_FIELD: tunnel_token})
 
     def unset_tunnel_token(self, relation: ops.Relation | None = None) -> None:
         """Unset cloudflared tunnel-token in the integration.

--- a/tox.ini
+++ b/tox.ini
@@ -103,7 +103,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.5.2.0
+    juju==3.6.0.0
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

When updating a secret's content with the exact same value, it still counts as a new revision of the secret. In this pull request, the charm is updated to modify the secret's content only when a change is needed, avoiding the creation of unnecessary secret revisions.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
